### PR TITLE
Bump to upstream version v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -x && \
     apk --no-cache add \
     git \
     make
-ARG TAG=v1.2.1
+ARG TAG=v1.3.0
 RUN git clone --depth=1 https://github.com/k8snetworkplumbingwg/ib-sriov-cni
 WORKDIR ib-sriov-cni
 RUN git fetch --all --tags --prune

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
-ARG GO_IMAGE=rancher/hardened-build-base:v1.24.4b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.24.5b1
 
 # Build the project
 FROM ${GO_IMAGE} as builder

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORG ?= rancher
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v1.2.1$(BUILD_META)
+TAG := v1.3.0$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version v1.3.0</summary>
            <p>changed lines [10] of file &#34;/tmp/updatecli/github/mgfritch/image-build-ib-sriov-cni/Dockerfile&#34;</p>
            <details>
                <summary>v1.3.0</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;* chore: bump x/net and cni pkg versions by @adrianchiris in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/109&#xD;&#xA;* Bump github.com/vishvananda/netlink from 1.2.1-beta.2 to 1.3.0 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/103&#xD;&#xA;* chore: bump go version to 1.24 by @adrianchiris in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/117&#xD;&#xA;* Bump docker/setup-buildx-action from 2 to 3 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/111&#xD;&#xA;* Bump actions/setup-go from 3 to 5 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/113&#xD;&#xA;* Bump docker/build-push-action from 4 to 6 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/112&#xD;&#xA;* Bump github.com/vishvananda/netlink from 1.3.1-0.20250303224720-0e7078ed04c8 to 1.3.1 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/118&#xD;&#xA;* update git ignore to not exclude internal build folders by @SchSeba in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/119&#xD;&#xA;* chore: bump alpine from 3.21.3 to 3.22.1 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/122&#xD;&#xA;* fix the defer functions being ignored by @Iceber in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/120&#xD;&#xA;* update go mod minimal version to &#34;.0&#34; by @SchSeba in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/124&#xD;&#xA;* fix: add MarshalJSON method for custom NetConf by @almaslennikov in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/123&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @Iceber made their first contribution in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/120&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/ib-sriov-cni/compare/v1.2.1...v1.3.0</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version v1.3.0</summary>
            <p>1 file(s) updated with &#34;TAG := v1.3.0$$(BUILD_META)&#34;:&#xA;&#xA;* Makefile&#xA;</p>
            <details>
                <summary>v1.3.0</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;* chore: bump x/net and cni pkg versions by @adrianchiris in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/109&#xD;&#xA;* Bump github.com/vishvananda/netlink from 1.2.1-beta.2 to 1.3.0 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/103&#xD;&#xA;* chore: bump go version to 1.24 by @adrianchiris in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/117&#xD;&#xA;* Bump docker/setup-buildx-action from 2 to 3 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/111&#xD;&#xA;* Bump actions/setup-go from 3 to 5 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/113&#xD;&#xA;* Bump docker/build-push-action from 4 to 6 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/112&#xD;&#xA;* Bump github.com/vishvananda/netlink from 1.3.1-0.20250303224720-0e7078ed04c8 to 1.3.1 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/118&#xD;&#xA;* update git ignore to not exclude internal build folders by @SchSeba in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/119&#xD;&#xA;* chore: bump alpine from 3.21.3 to 3.22.1 by @dependabot[bot] in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/122&#xD;&#xA;* fix the defer functions being ignored by @Iceber in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/120&#xD;&#xA;* update go mod minimal version to &#34;.0&#34; by @SchSeba in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/124&#xD;&#xA;* fix: add MarshalJSON method for custom NetConf by @almaslennikov in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/123&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @Iceber made their first contribution in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/120&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/ib-sriov-cni/compare/v1.2.1...v1.3.0</pre>
            </details>
        </details>
        <details id="d39ad2ff035b173d1b77ca29cb2371341365d7a4c859e7c47315ed7dde7977f8">
            <summary>Bump to build base version v1.24.5b1</summary>
            <p>changed lines [2] of file &#34;/tmp/updatecli/github/mgfritch/image-build-ib-sriov-cni/Dockerfile&#34;</p>
            <details>
                <summary>v1.24.5b1</summary>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

